### PR TITLE
Update validate-documentation-links.yml

### DIFF
--- a/.github/workflows/validate-documentation-links.yml
+++ b/.github/workflows/validate-documentation-links.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           command: check_broken_paths
           directory: ./
-          guide-url: 'https://github.com/microsoft/Phi-3CookBook/blob/main/CONTRIBUTING.md'
+          guide-url: 'https://github.com/microsoft/PhiCookBook/blob/main/CONTRIBUTING.md'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   check-urls-locale:
@@ -43,7 +43,7 @@ jobs:
         with:
           command: check_urls_locale
           directory: ./
-          guide-url: 'https://github.com/microsoft/Phi-3CookBook/blob/main/CONTRIBUTING.md'
+          guide-url: 'https://github.com/microsoft/PhiCookBook/blob/main/CONTRIBUTING.md'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   check-broken-urls:
@@ -58,5 +58,5 @@ jobs:
         with:
           command: check_broken_urls
           directory: ./
-          guide-url: 'https://github.com/microsoft/Phi-3CookBook/blob/main/CONTRIBUTING.md'
+          guide-url: 'https://github.com/microsoft/PhiCookBook/blob/main/CONTRIBUTING.md'
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update url to new phicookbook url

## Purpose

Update yml to correct urls based on new cookbook url https://github.com/microsoft/PhiCookBook


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```


