### PR TITLE
Add missing Phi4 links to model family documentation

### DIFF
--- a/md/01.Introduction/01/01.PhiFamily.md
+++ b/md/01.Introduction/01/01.PhiFamily.md
@@ -26,8 +26,8 @@ The Phi Family started with Phi-1 for Python Code generation, continued to Phi-1
 |[Phi-4](https://huggingface.co/microsoft/phi-4)|14B|YES|YES| NO |NO |NO |NO |
 |[Phi-4-mini](https://huggingface.co/microsoft/Phi-4-mini-instruct)|3.8B|YES|YES| NO |NO |NO |NO |
 |[Phi-4-multimodal](https://huggingface.co/microsoft/Phi-4-multimodal-instruct)|5.6B|YES|YES| NO |YES |YES |NO |
-|[Phi-4-reasoning](#)|3.8B|YES|YES| YES |NO |NO |NO |
-|[Phi-4-mini-reasoning](#)|3.8B|YES|YES| YES |NO |NO |NO |
+|[Phi-4-reasoning](https://huggingface.co/microsoft/Phi-4-reasoning)|3.8B|YES|YES| YES |NO |NO |NO |
+|[Phi-4-mini-reasoning](https://huggingface.co/microsoft/Phi-4-mini-reasoning)|3.8B|YES|YES| YES |NO |NO |NO |
 
 
 </div>


### PR DESCRIPTION
Closes #362

## Purpose

It appears that two of the models in the [Phi Family Models list](https://github.com/microsoft/PhiCookBook/blob/main/md/01.Introduction/01/01.PhiFamily.md#phi-family-models) are missing links to Hugging Face. This PR adds the links.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


