### PR TITLE
Fix typo in Jupyter Notebook description

### DIFF
--- a/translations/ja/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-mini_with_whisper.md
+++ b/translations/ja/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-mini_with_whisper.md
@@ -26,7 +26,7 @@
 
 ## Whisper搭載インタラクティブPhi 3 Mini 4KインストラクションチャットボットのE2Eサンプル
 
-[Interactive Phi 3 Mini 4K Instruct Chatbot with Whisper](https://github.com/microsoft/Phi-3CookBook/blob/main/code/06.E2E/E2E_Phi-3-mini-4k-instruct-Whispser_Demo.ipynb) というタイトルのJupyterノートブックは、Microsoft Phi 3 Mini 4K instructデモを使って音声または書かれたテキスト入力からテキストを生成する方法を示しています。ノートブックにはいくつかの関数が定義されています：
+[Interactive Phi 3 Mini 4K Instruct Chatbot with Whisper](https://github.com/microsoft/Phi-3CookBook/blob/main/code/06.E2E/E2E_Phi-3-mini-4k-instruct-Whispser_Demo.ipynb) というタイトルのJupyter Notebookは、Microsoft Phi 3 Mini 4K instructデモを使って音声または書かれたテキスト入力からテキストを生成する方法を示しています。ノートブックにはいくつかの関数が定義されています：
 
 1. `tts_file_name(text)`: 入力テキストに基づいて生成された音声ファイルを保存するためのファイル名を生成します。  
 1. `edge_free_tts(chunks_list,speed,voice_name,save_path)`: Edge TTS APIを使用して、入力テキストのチャンクリストから音声ファイルを生成します。入力パラメータはチャンクのリスト、音声速度、音声名、生成した音声ファイルの保存パスです。  


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
https://github.com/microsoft/PhiCookBook/blob/main/translations/ja/md/02.Application/01.TextAndChat/Phi3/E2E_Phi-3-mini_with_whisper.md 

<img width="1172" height="133" alt="image" src="https://github.com/user-attachments/assets/8896fe96-f3c6-49fe-8b1f-2b1e31c8aa3d" />

https://github.com/Azure/co-op-translator/issues/474

#PingMSFTDocs


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Does this require changes to learn.microsoft.com docs?

This repository is referenced by (https://azure.microsoft.com/products/phi-3)
which includes deployment, settings and usage instructions.

```
[ ] Yes
[x] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```


