### PR TITLE
Android inference: add Phi-4-mini-reasoning on LiteRT-LM

### DIFF
--- a/md/01.Introduction/03/Android_Inference.md
+++ b/md/01.Introduction/03/Android_Inference.md
@@ -39,4 +39,8 @@ If you want to use `.gguf` files in the cloud and on edge devices simultaneously
 2. Download the APK file (148MB) and install it on your device.
 3. Launch the MLC Chat app. You'll see a list of AI models, including Phi-3-mini.
 
+### Run Phi-4-mini-reasoning with LiteRT-LM
+
+[Phi-4-mini-reasoning](https://huggingface.co/litert-community/Phi-4-mini-reasoning) is available as a community-converted int4 `.litertlm` bundle for Google's [LiteRT-LM](https://github.com/google-ai-edge/LiteRT-LM) on-device runtime. On Android it runs on CPU or GPU through the [Google AI Edge Gallery](https://github.com/google-ai-edge/gallery) app (import the bundle from Hugging Face inside the app) or through the LiteRT-LM Kotlin API; the same bundle also runs on iOS, macOS, Linux and Windows. The model card lists the measured speeds and the run commands.
+
 In summary, Phi-3-mini opens up exciting possibilities for generative AI on edge devices, and you can start exploring its capabilities on Android.


### PR DESCRIPTION
Thanks for keeping the per-platform inference pages. This adds one section to `md/01.Introduction/03/Android_Inference.md` for LiteRT-LM, Google AI Edge's on-device LLM runtime, next to the existing Ollama, LlamaEdge and MLC Chat options. The linked bundle is my int4 conversion of Phi-4-mini-reasoning, hosted in Google's litert-community org.

- `litert-lm benchmark` on an Apple M4 Max: 19.8 tok/s decode on CPU, 82.8 tok/s on the Metal GPU; Raspberry Pi 5 CPU rows are on the card.
- Android: runs on the GPU backend on a Galaxy S26; no phone speed is quoted because there is no CPU row from the same handset to compare it with.
- GSM8K (n=100, greedy, max_tokens 2048): 81.0% vs 89.0% for the bf16 reference.
- Source page only; `translations/` is left to the localization bot.

Card: https://huggingface.co/litert-community/Phi-4-mini-reasoning — runtime: https://github.com/google-ai-edge/LiteRT-LM

Happy to reword or move the section wherever it fits the cookbook. Thanks again.



---

One data point behind this section, in case it's useful.

In a small test I ran, coding agents building on-device apps shortlisted Phi in 6 of 12 runs and chose it in none, for one reason each time: at 3.8B it was too big for the speed they wanted. What none of the six notes had was a phone speed for a 3.8B model.

Their own notes: “viable but larger download and less commonly used in the MLX ecosystem; skipped to keep the comparison space small” (Sonnet, on Phi-3.5-mini); the other five said the same in terms of decode speed or download size. The setup: three agents (Claude Fable 5.1, Claude Sonnet 5, Codex with GPT-5.5), ten on-device app tasks each, no hint about which model or runtime to use, and each agent wrote down its choice and reason before coding. I ran it to see how agents treat the models I convert.

The card this section links has that number now: 13.1 tok/s decode on a Galaxy S26, GPU backend (8.4 tok/s on its CPU), and 6.8 tok/s on a Pixel 8a, both over a 511-token prompt and 256 generated tokens. Whether a cookbook section changes a shortlist, I don't know from 30 runs.

I repeat the run monthly. If this lands, I'll post here what the agents pick next time, whichever way it goes. Nothing is needed from you for that. Thanks again.
